### PR TITLE
[ENT-4682] Upgrade sshd-core version to 2.3.0

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.cli</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH CLI</name>
   <description>The CRaSH command line interface module</description>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Connectors</name>
 

--- a/connectors/ssh/pom.xml
+++ b/connectors/ssh/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.connectors</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors.ssh</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Connectors - SSH</name>
   <description>The CRaSH SSH connector</description>

--- a/connectors/ssh/src/main/java/org/crsh/auth/FilePublicKeyProvider.java
+++ b/connectors/ssh/src/main/java/org/crsh/auth/FilePublicKeyProvider.java
@@ -19,6 +19,7 @@
 package org.crsh.auth;
 
 import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;
+import org.apache.sshd.common.session.SessionContext;
 import org.apache.sshd.common.util.security.SecurityUtils;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.openssl.PEMException;
@@ -52,7 +53,7 @@ class FilePublicKeyProvider extends AbstractKeyPairProvider {
     this.files = files;
   }
 
-  public Iterable<KeyPair> loadKeys() {
+  public Iterable<KeyPair> loadKeys(SessionContext session) {
     if (!SecurityUtils.isBouncyCastleRegistered()) {
       throw new IllegalStateException("BouncyCastle must be registered as a JCE provider");
     }

--- a/connectors/ssh/src/main/java/org/crsh/auth/KeyAuthenticationPlugin.java
+++ b/connectors/ssh/src/main/java/org/crsh/auth/KeyAuthenticationPlugin.java
@@ -65,7 +65,7 @@ public class KeyAuthenticationPlugin extends CRaSHPlugin<KeyAuthenticationPlugin
   }
 
   @Override
-  public void init() {
+  public void init() throws Exception {
     String authorizedKeyPath = getContext().getProperty(AUTHORIZED_KEY_PATH);
     if (authorizedKeyPath != null) {
       File f = new File(authorizedKeyPath);
@@ -75,7 +75,7 @@ public class KeyAuthenticationPlugin extends CRaSHPlugin<KeyAuthenticationPlugin
         keys = new LinkedHashSet<PublicKey>();
         KeyPairProvider provider = new FilePublicKeyProvider(new String[]{authorizedKeyPath});
         for (String type : TYPES) {
-          KeyPair pair = provider.loadKey(type);
+          KeyPair pair = provider.loadKey(null, type);
           if (pair != null) {
             PublicKey key = pair.getPublic();
             if (key != null) {

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/AbstractCommand.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/AbstractCommand.java
@@ -18,7 +18,7 @@
  */
 package org.crsh.ssh.term;
 
-import org.apache.sshd.server.Command;
+import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.ExitCallback;
 import org.apache.sshd.server.SessionAware;
 import org.apache.sshd.server.session.ServerSession;

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/CRaSHCommand.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/CRaSHCommand.java
@@ -18,6 +18,7 @@
  */
 package org.crsh.ssh.term;
 
+import org.apache.sshd.server.channel.ChannelSession;
 import org.crsh.command.ShellSafety;
 import org.crsh.console.jline.Terminal;
 import org.crsh.console.jline.console.ConsoleReader;
@@ -66,7 +67,7 @@ public class CRaSHCommand extends AbstractCommand implements Runnable, Terminal 
   /** . */
   private JLineProcessor console;
 
-  public void start(Environment env) throws IOException {
+  public void start(ChannelSession channel, Environment env) throws IOException {
     context = new SSHContext(env);
     encoding = context.encoding != null ? context.encoding.name() : factory.encoding.name();
     thread = new Thread(this, "CRaSH");
@@ -79,7 +80,7 @@ public class CRaSHCommand extends AbstractCommand implements Runnable, Terminal 
     return context;
   }
 
-  public void destroy() {
+  public void destroy(ChannelSession channel) {
     Utils.close(console);
     thread.interrupt();
   }

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/CRaSHCommandFactory.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/CRaSHCommandFactory.java
@@ -18,13 +18,13 @@
  */
 package org.crsh.ssh.term;
 
-import org.apache.sshd.common.Factory;
-import org.apache.sshd.server.Command;
+import org.apache.sshd.server.channel.ChannelSession;
+import org.apache.sshd.server.command.Command;
 import org.crsh.shell.ShellFactory;
 
 import java.nio.charset.Charset;
 
-public class CRaSHCommandFactory implements Factory<Command> {
+public class CRaSHCommandFactory implements org.apache.sshd.server.shell.ShellFactory {
 
   /** . */
   final ShellFactory shellFactory;
@@ -38,7 +38,7 @@ public class CRaSHCommandFactory implements Factory<Command> {
   }
 
   @Override
-  public Command create() {
+  public Command createShell(ChannelSession channel) {
     return new CRaSHCommand(this);
   }
 }

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/FailCommand.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/FailCommand.java
@@ -19,6 +19,7 @@
 package org.crsh.ssh.term;
 
 import org.apache.sshd.server.Environment;
+import org.apache.sshd.server.channel.ChannelSession;
 
 import java.io.IOException;
 
@@ -40,7 +41,7 @@ public class FailCommand extends AbstractCommand {
     this.throwable = throwable;
   }
 
-  public void start(Environment env) throws IOException {
+  public void start(ChannelSession channel, Environment env) throws IOException {
     IOException ioe = new IOException("Failure " + failure);
     if (throwable != null) {
       ioe.initCause(throwable);
@@ -48,6 +49,6 @@ public class FailCommand extends AbstractCommand {
     throw ioe;
   }
 
-  public void destroy() {
+  public void destroy(ChannelSession channel) {
   }
 }

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
@@ -22,7 +22,7 @@ import org.apache.sshd.server.SshServer;
 import org.apache.sshd.common.keyprovider.KeyPairProvider;
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.session.Session;
-import org.apache.sshd.server.Command;
+import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.auth.password.PasswordAuthenticator;
 import org.apache.sshd.server.ServerFactoryManager;
 import org.apache.sshd.server.auth.password.PasswordChangeRequiredException;

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/URLKeyPairProvider.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/URLKeyPairProvider.java
@@ -19,6 +19,7 @@
 package org.crsh.ssh.term;
 
 import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;
+import org.apache.sshd.common.session.SessionContext;
 import org.apache.sshd.common.util.security.SecurityUtils;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
@@ -46,7 +47,7 @@ public class URLKeyPairProvider extends AbstractKeyPairProvider {
   }
 
   @Override
-  public Iterable<java.security.KeyPair> loadKeys() {
+  public Iterable<java.security.KeyPair> loadKeys(SessionContext session) {
     if (!SecurityUtils.isBouncyCastleRegistered()) {
       throw new IllegalStateException("BouncyCastle must be registered as a JCE provider");
     }

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/inline/SSHInlineCommand.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/inline/SSHInlineCommand.java
@@ -1,6 +1,7 @@
 package org.crsh.ssh.term.inline;
 
 import org.apache.sshd.server.Environment;
+import org.apache.sshd.server.channel.ChannelSession;
 import org.crsh.auth.AuthInfo;
 import org.crsh.command.ShellSafety;
 import org.crsh.plugin.PluginContext;
@@ -47,13 +48,13 @@ public class SSHInlineCommand extends AbstractCommand implements Runnable {
     this.pluginContext = pluginContext;
   }
 
-  public void start(Environment environment) throws IOException {
+  public void start(ChannelSession channel, Environment environment) throws IOException {
     this.env = environment;
     thread = new Thread(this, "CRaSH");
     thread.start();
   }
 
-  public void destroy() {
+  public void destroy(ChannelSession channel) {
     thread.interrupt();
   }
 

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/inline/SSHInlinePlugin.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/inline/SSHInlinePlugin.java
@@ -19,7 +19,7 @@
 
 package org.crsh.ssh.term.inline;
 
-import org.apache.sshd.server.Command;
+import org.apache.sshd.server.command.Command;
 import org.crsh.ssh.term.scp.CommandPlugin;
 
 /***

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/scp/CommandPlugin.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/scp/CommandPlugin.java
@@ -19,7 +19,7 @@
 
 package org.crsh.ssh.term.scp;
 
-import org.apache.sshd.server.Command;
+import org.apache.sshd.server.command.Command;
 import org.crsh.plugin.CRaSHPlugin;
 
 public abstract class CommandPlugin extends CRaSHPlugin<CommandPlugin> {

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/scp/SCPCommandFactory.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/scp/SCPCommandFactory.java
@@ -18,8 +18,9 @@
  */
 package org.crsh.ssh.term.scp;
 
-import org.apache.sshd.server.Command;
-import org.apache.sshd.server.CommandFactory;
+import org.apache.sshd.server.channel.ChannelSession;
+import org.apache.sshd.server.command.Command;
+import org.apache.sshd.server.command.CommandFactory;
 import org.crsh.plugin.PluginContext;
 import org.crsh.ssh.term.FailCommand;
 
@@ -38,7 +39,7 @@ public class SCPCommandFactory implements CommandFactory {
     this.pluginContext = pluginContext;
   }
 
-  public Command createCommand(String command) {
+  public Command createCommand(ChannelSession channel, String command) {
     // Just in case
     command = command.trim();
 

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/subsystem/SubsystemFactoryPlugin.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/subsystem/SubsystemFactoryPlugin.java
@@ -20,7 +20,7 @@
 package org.crsh.ssh.term.subsystem;
 
 import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.Command;
+import org.apache.sshd.server.command.Command;
 import org.crsh.plugin.CRaSHPlugin;
 
 import java.util.List;

--- a/connectors/ssh/src/test/java/org/crsh/auth/FilePublicKeyProviderTest.java
+++ b/connectors/ssh/src/test/java/org/crsh/auth/FilePublicKeyProviderTest.java
@@ -13,7 +13,7 @@ public class FilePublicKeyProviderTest {
     String pubKeyFile = Thread.currentThread().getContextClassLoader().getResource("test_authorized_key.pem").getFile();
     assertTrue(new File(pubKeyFile).exists());
     FilePublicKeyProvider SUT = new FilePublicKeyProvider(new String[]{pubKeyFile});
-    assertTrue(SUT.loadKeys().iterator().hasNext());
+    assertTrue(SUT.loadKeys(null).iterator().hasNext());
   }
 
 }

--- a/connectors/telnet/pom.xml
+++ b/connectors/telnet/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.connectors</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors.telnet</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Connectors - Telnet</name>
   <description>The CRaSH Telnet connector</description>

--- a/connectors/web/pom.xml
+++ b/connectors/web/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.connectors</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors.web</artifactId>
   <packaging>war</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Connectors - Web</name>
   <description>The CRaSH Web connector</description>

--- a/distrib/pom.xml
+++ b/distrib/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.distrib</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Distrib</name>
   <description>The CRaSH distribution</description>

--- a/doc/api/pom.xml
+++ b/doc/api/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>crash.doc</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc.api</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Doc API</name>
   <description>The CRaSH API documentation</description>

--- a/doc/cookbook/pom.xml
+++ b/doc/cookbook/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>crash.doc</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc.cookbook</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Doc Cookbook</name>
   <description>The CRaSH cookbook documentation</description>

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Doc</name>
 

--- a/doc/reference/pom.xml
+++ b/doc/reference/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>crash.doc</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc.reference</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Doc Reference</name>
   <description>The CRaSH reference documentation</description>

--- a/embed/pom.xml
+++ b/embed/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.embed</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Embed</name>
 

--- a/embed/spring/pom.xml
+++ b/embed/spring/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.embed</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.embed.spring</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Embed Spring</name>
   <description>The CRaSH Spring integration module</description>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.packaging</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Packaging</name>
   <description>The CRaSH packaging module</description>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.plugins</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Plugins</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,7 @@
       <dependency>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd-core</artifactId>
-        <version>1.6.0</version>
+        <version>2.3.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,11 @@
   <groupId>org.crashub</groupId>
   <artifactId>crash.parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
+  <!-- To update project version run the following:
+    mvn versions:set -DnewVersion=<new version>
+    mvn versions:commit # Necessary to remove the backup file pom.xml
+   -->
 
   <parent>
     <groupId>org.sonatype.oss</groupId>
@@ -112,12 +116,12 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.cli</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.cli</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -125,25 +129,25 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <type>jar</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <type>test-jar</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <classifier>standalone</classifier>
       </dependency>
 
@@ -151,18 +155,18 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.telnet</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.telnet</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.telnet</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <classifier>standalone</classifier>
       </dependency>
 
@@ -170,18 +174,18 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.ssh</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.ssh</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.ssh</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <classifier>standalone</classifier>
       </dependency>
 
@@ -189,12 +193,12 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.web</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.web</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -202,12 +206,12 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.embed.spring</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.embed.spring</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -215,32 +219,32 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <type>war</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <type>war</type>
         <classifier>spring</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <type>zip</type>
         <classifier>mule-app</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <type>tar.gz</type>
       </dependency>
 
@@ -276,7 +280,7 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.api</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <classifier>javadoc</classifier>
       </dependency>
 
@@ -284,13 +288,13 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.reference</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <type>pdf</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.reference</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <classifier>html</classifier>
         <type>zip</type>
       </dependency>
@@ -299,13 +303,13 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.cookbook</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <type>pdf</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.cookbook</artifactId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.7.2-SNAPSHOT</version>
         <classifier>html</classifier>
         <type>zip</type>
       </dependency>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.shell</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
 
   <name>CRaSH Shell</name>
   <description>The Shell module</description>

--- a/shell/src/main/java/org/crsh/plugin/CRaSHPlugin.java
+++ b/shell/src/main/java/org/crsh/plugin/CRaSHPlugin.java
@@ -121,7 +121,7 @@ public abstract class CRaSHPlugin<P> {
   /**
    * Implement this method to know about init life cycle callback.
    */
-  public void init() {
+  public void init() throws Exception {
   }
 
   /**


### PR DESCRIPTION
Upgrading Apache sshd to the latest version (2.3.0) to address security vulnerabilities.
Project version bumped to 1.7.2-SNAPSHOT in a separate commit.

Removal of outdated ciphers and algorithms will be covered by separate PR.