### PR TITLE
[ENT-4682] Remove outdated ciphers and algorithms

### DIFF
--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHFactories.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHFactories.java
@@ -1,0 +1,87 @@
+package org.crsh.ssh.term;
+
+import org.apache.sshd.common.NamedFactory;
+import org.apache.sshd.common.cipher.BuiltinCiphers;
+import org.apache.sshd.common.cipher.Cipher;
+import org.apache.sshd.common.compression.BuiltinCompressions;
+import org.apache.sshd.common.compression.Compression;
+import org.apache.sshd.common.compression.CompressionFactory;
+import org.apache.sshd.common.kex.BuiltinDHFactories;
+import org.apache.sshd.common.kex.KeyExchange;
+import org.apache.sshd.common.mac.BuiltinMacs;
+import org.apache.sshd.common.mac.Mac;
+import org.apache.sshd.common.signature.BuiltinSignatures;
+import org.apache.sshd.common.signature.Signature;
+import org.apache.sshd.server.ServerBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * ENT-4682: List of supported SSH algorithms and ciphers according to modern security requirements.
+ * Outdated MD5, SHA-1, CBC, 3-DES, RC4 and Blowfish are excluded.
+ */
+public class SSHFactories {
+    private static final List<BuiltinSignatures> SIGNATURE_PREFERENCE =
+            Collections.unmodifiableList(
+                    Arrays.asList(
+                            BuiltinSignatures.nistp256,
+                            BuiltinSignatures.nistp384,
+                            BuiltinSignatures.nistp521,
+                            BuiltinSignatures.ed25519,
+                            BuiltinSignatures.rsaSHA512,
+                            BuiltinSignatures.rsaSHA256
+                    ));
+
+    private static final List<BuiltinCiphers> CIPHER_PREFERENCE =
+            Collections.unmodifiableList(
+                    Arrays.asList(
+                            BuiltinCiphers.aes128ctr,
+                            BuiltinCiphers.aes192ctr,
+                            BuiltinCiphers.aes256ctr
+                    ));
+
+    private static final List<BuiltinDHFactories> KEX_PREFERENCE =
+            Collections.unmodifiableList(
+                    Arrays.asList(
+                            BuiltinDHFactories.ecdhp521,
+                            BuiltinDHFactories.ecdhp384,
+                            BuiltinDHFactories.ecdhp256,
+                            BuiltinDHFactories.dhgex256,
+                            BuiltinDHFactories.dhg14_256
+                    ));
+
+    private static final List<BuiltinMacs> MAC_PREFERENCE =
+            Collections.unmodifiableList(
+                    Arrays.asList(
+                            BuiltinMacs.hmacsha256,
+                            BuiltinMacs.hmacsha512
+                    ));
+
+    private static final List<CompressionFactory> COMPRESSION_PREFERENCE =
+            Collections.unmodifiableList(
+                    Arrays.asList(
+                            BuiltinCompressions.none
+                    ));
+
+    public static List<NamedFactory<Signature>> setUpSignatureFactories() {
+        return NamedFactory.setUpBuiltinFactories(false, SIGNATURE_PREFERENCE);
+    }
+
+    public static List<NamedFactory<Cipher>> setUpCipherFactories() {
+        return NamedFactory.setUpBuiltinFactories(false, CIPHER_PREFERENCE);
+    }
+
+    public static List<NamedFactory<KeyExchange>> setUpKeyExchangeFactories() {
+        return NamedFactory.setUpTransformedFactories(false, KEX_PREFERENCE, ServerBuilder.DH2KEX);
+    }
+
+    public static List<NamedFactory<Mac>> setUpMacFactories() {
+        return NamedFactory.setUpBuiltinFactories(false, MAC_PREFERENCE);
+    }
+
+    public static List<NamedFactory<Compression>> setUpCompressionFactories() {
+        return NamedFactory.setUpBuiltinFactories(false, COMPRESSION_PREFERENCE);
+    }
+}

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHFactories.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHFactories.java
@@ -31,7 +31,8 @@ public class SSHFactories {
                             BuiltinSignatures.nistp521,
                             BuiltinSignatures.ed25519,
                             BuiltinSignatures.rsaSHA512,
-                            BuiltinSignatures.rsaSHA256
+                            BuiltinSignatures.rsaSHA256,
+                            BuiltinSignatures.rsa
                     ));
 
     private static final List<BuiltinCiphers> CIPHER_PREFERENCE =

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHFactories.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHFactories.java
@@ -48,8 +48,9 @@ public class SSHFactories {
                             BuiltinDHFactories.ecdhp521,
                             BuiltinDHFactories.ecdhp384,
                             BuiltinDHFactories.ecdhp256,
-                            BuiltinDHFactories.dhgex256,
-                            BuiltinDHFactories.dhg14_256
+                            BuiltinDHFactories.dhg14_256,
+                            BuiltinDHFactories.dhg16_512,
+                            BuiltinDHFactories.dhg18_512
                     ));
 
     private static final List<BuiltinMacs> MAC_PREFERENCE =

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
@@ -149,6 +149,12 @@ public class SSHLifeCycle {
       server.setShellFactory(new CRaSHCommandFactory(factory, encoding));
       server.setCommandFactory(new SCPCommandFactory(context));
       server.setKeyPairProvider(keyPairProvider);
+      // Disable outdated algorithms and ciphers
+      server.setSignatureFactories(SSHFactories.setUpSignatureFactories());
+      server.setCipherFactories(SSHFactories.setUpCipherFactories());
+      server.setKeyExchangeFactories(SSHFactories.setUpKeyExchangeFactories());
+      server.setMacFactories(SSHFactories.setUpMacFactories());
+      server.setCompressionFactories(SSHFactories.setUpCompressionFactories());
 
       //
       ArrayList<NamedFactory<Command>> namedFactoryList = new ArrayList<NamedFactory<Command>>(0);


### PR DESCRIPTION
To remove insecure ciphers and algorithms from crash SSH server incl. MD5, SHA-1, CBC, 3-DES, RC4 and Blowfish. See ENT-4682 for details.

The OLD list:
```
$ nmap --script ssh2-enum-algos -sV -p 2223 localhost
...
PORT     STATE SERVICE VERSION
2223/tcp open  ssh     Apache Mina sshd 1.6.0 (protocol 2.0)
| ssh2-enum-algos:
|   kex_algorithms: (7)
|       ecdh-sha2-nistp521
|       ecdh-sha2-nistp384
|       ecdh-sha2-nistp256
|       diffie-hellman-group-exchange-sha256
|       diffie-hellman-group-exchange-sha1
|       diffie-hellman-group14-sha1
|       diffie-hellman-group1-sha1
|   server_host_key_algorithms: (1)
|       ssh-rsa
|   encryption_algorithms: (10)
|       aes128-ctr
|       aes192-ctr
|       aes256-ctr
|       arcfour256
|       arcfour128
|       aes128-cbc
|       3des-cbc
|       blowfish-cbc
|       aes192-cbc
|       aes256-cbc
|   mac_algorithms: (6)
|       hmac-md5
|       hmac-sha1
|       hmac-sha2-256
|       hmac-sha2-512
|       hmac-sha1-96
|       hmac-md5-96
|   compression_algorithms: (3)
|       none
|       zlib
|_      zlib@openssh.com
```

The NEW list:
```
$ nmap --script ssh2-enum-algos -sV -p 2223 localhost
...
PORT     STATE SERVICE VERSION
2223/tcp open  ssh     (protocol 2.0)
| fingerprint-strings:
|   NULL:
|_    SSH-2.0-APACHE-SSHD-2.3.0
| ssh2-enum-algos:
|   kex_algorithms: (6)
|       ecdh-sha2-nistp521
|       ecdh-sha2-nistp384
|       ecdh-sha2-nistp256
|       diffie-hellman-group14-sha256
|       diffie-hellman-group16-sha512
|       diffie-hellman-group18-sha512
|   server_host_key_algorithms: (3)
|       rsa-sha2-512
|       rsa-sha2-256
|       ssh-rsa
|   encryption_algorithms: (3)
|       aes128-ctr
|       aes192-ctr
|       aes256-ctr
|   mac_algorithms: (2)
|       hmac-sha2-256
|       hmac-sha2-512
|   compression_algorithms: (1)
|_      none
...
```

Mozilla compliance check BEFORE:
```
$ ssh_scan -t 0.0.0.0 -p 2223
...
    "compliance": {
      "policy": "Mozilla Modern",
      "compliant": false,
      "recommendations": [
        "Add these key exchange algorithms: curve25519-sha256@libssh.org",
        "Add these MAC algorithms: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,umac-128@openssh.com",
        "Add these encryption ciphers: chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com",
        "Remove these key exchange algorithms: diffie-hellman-group-exchange-sha1, diffie-hellman-group14-sha1, diffie-hellman-group1-sha1",
        "Remove these MAC algorithms: hmac-md5, hmac-sha1, hmac-sha1-96, hmac-md5-96",
        "Remove these encryption ciphers: arcfour256, arcfour128, aes128-cbc, 3des-cbc, blowfish-cbc, aes192-cbc, aes256-cbc",
        "Remove these authentication methods: password, keyboard-interactive"
      ],
      "references": [
        "https://wiki.mozilla.org/Security/Guidelines/OpenSSH"
      ],
      "grade": "F"
    },
    "start_time": "2019-12-16 17:59:45 +0000",
    "end_time": "2019-12-16 17:59:46 +0000",
    "scan_duration_seconds": 0.1155934
  }
]
```

Mozilla compliance check AFTER:
```
$ ssh_scan -t 0.0.0.0 -p 2223
...
    "compliance": {
      "policy": "Mozilla Modern",
      "compliant": false,
      "recommendations": [
        "Add these key exchange algorithms: curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256",
        "Add these MAC algorithms: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,umac-128@openssh.com",
        "Add these encryption ciphers: chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com",
        "Remove these key exchange algorithms: diffie-hellman-group14-sha256, diffie-hellman-group16-sha512, diffie-hellman-group18-sha512",
        "Remove these authentication methods: password, keyboard-interactive"
      ],
      "references": [
        "https://wiki.mozilla.org/Security/Guidelines/OpenSSH"
      ],
      "grade": "F"
    },
```

Done sanity check on the corda shell - looks good.

ssh-audit BEFORE:
```
$ python3 ./ssh-audit.py -p 2222 localhost
# general
(gen) banner: SSH-2.0-SSHD-CORE-1.6.0
(gen) compatibility: OpenSSH 5.9-6.6, Dropbear SSH 2013.62+ (some functionality from 0.52)
(gen) compression: enabled (zlib, zlib@openssh.com)

# key exchange algorithms
(kex) ecdh-sha2-nistp521                    -- [fail] using weak elliptic curves
                                            `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
(kex) ecdh-sha2-nistp384                    -- [fail] using weak elliptic curves
                                            `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
(kex) ecdh-sha2-nistp256                    -- [fail] using weak elliptic curves
                                            `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
(kex) diffie-hellman-group-exchange-sha256  -- [warn] using custom size modulus (possibly weak)
                                            `- [info] available since OpenSSH 4.4
(kex) diffie-hellman-group-exchange-sha1    -- [fail] removed (in server) since OpenSSH 6.7, unsafe algorithm
                                            `- [warn] using weak hashing algorithm
                                            `- [info] available since OpenSSH 2.3.0
(kex) diffie-hellman-group14-sha1           -- [warn] using weak hashing algorithm
                                            `- [info] available since OpenSSH 3.9, Dropbear SSH 0.53
(kex) diffie-hellman-group1-sha1            -- [fail] removed (in server) since OpenSSH 6.7, unsafe algorithm
                                            `- [fail] disabled (in client) since OpenSSH 7.0, logjam attack
                                            `- [warn] using small 1024-bit modulus
                                            `- [warn] using weak hashing algorithm
                                            `- [info] available since OpenSSH 2.3.0, Dropbear SSH 0.28

# host-key algorithms
(key) ssh-rsa                               -- [info] available since OpenSSH 2.5.0, Dropbear SSH 0.28

# encryption algorithms (ciphers)
(enc) aes128-ctr                            -- [info] available since OpenSSH 3.7, Dropbear SSH 0.52
(enc) aes192-ctr                            -- [info] available since OpenSSH 3.7
(enc) aes256-ctr                            -- [info] available since OpenSSH 3.7, Dropbear SSH 0.52
(enc) arcfour256                            -- [fail] removed (in server) since OpenSSH 6.7, unsafe algorithm
                                            `- [warn] disabled (in client) since OpenSSH 7.2, legacy algorithm
                                            `- [warn] using weak cipher
                                            `- [info] available since OpenSSH 4.2
(enc) arcfour128                            -- [fail] removed (in server) since OpenSSH 6.7, unsafe algorithm
                                            `- [warn] disabled (in client) since OpenSSH 7.2, legacy algorithm
                                            `- [warn] using weak cipher
                                            `- [info] available since OpenSSH 4.2
(enc) aes128-cbc                            -- [fail] removed (in server) since OpenSSH 6.7, unsafe algorithm
                                            `- [warn] using weak cipher mode
                                            `- [info] available since OpenSSH 2.3.0, Dropbear SSH 0.28
(enc) 3des-cbc                              -- [fail] removed (in server) since OpenSSH 6.7, unsafe algorithm
                                            `- [warn] using weak cipher
                                            `- [warn] using weak cipher mode
                                            `- [warn] using small 64-bit block size
                                            `- [info] available since OpenSSH 1.2.2, Dropbear SSH 0.28
(enc) blowfish-cbc                          -- [fail] removed (in server) since OpenSSH 6.7, unsafe algorithm
                                            `- [fail] disabled since Dropbear SSH 0.53
                                            `- [warn] disabled (in client) since OpenSSH 7.2, legacy algorithm
                                            `- [warn] using weak cipher mode
                                            `- [warn] using small 64-bit block size
                                            `- [info] available since OpenSSH 1.2.2, Dropbear SSH 0.28
(enc) aes192-cbc                            -- [fail] removed (in server) since OpenSSH 6.7, unsafe algorithm
                                            `- [warn] using weak cipher mode
                                            `- [info] available since OpenSSH 2.3.0
(enc) aes256-cbc                            -- [fail] removed (in server) since OpenSSH 6.7, unsafe algorithm
                                            `- [warn] using weak cipher mode
                                            `- [info] available since OpenSSH 2.3.0, Dropbear SSH 0.47

# message authentication code algorithms
(mac) hmac-md5                              -- [fail] removed (in server) since OpenSSH 6.7, unsafe algorithm
                                            `- [warn] disabled (in client) since OpenSSH 7.2, legacy algorithm
                                            `- [warn] using encrypt-and-MAC mode
                                            `- [warn] using weak hashing algorithm
                                            `- [info] available since OpenSSH 2.1.0, Dropbear SSH 0.28
(mac) hmac-sha1                             -- [warn] using encrypt-and-MAC mode
                                            `- [warn] using weak hashing algorithm
                                            `- [info] available since OpenSSH 2.1.0, Dropbear SSH 0.28
(mac) hmac-sha2-256                         -- [warn] using encrypt-and-MAC mode
                                            `- [info] available since OpenSSH 5.9, Dropbear SSH 2013.56
(mac) hmac-sha2-512                         -- [warn] using encrypt-and-MAC mode
                                            `- [info] available since OpenSSH 5.9, Dropbear SSH 2013.56
(mac) hmac-sha1-96                          -- [fail] removed (in server) since OpenSSH 6.7, unsafe algorithm
                                            `- [warn] disabled (in client) since OpenSSH 7.2, legacy algorithm
                                            `- [warn] using encrypt-and-MAC mode
                                            `- [warn] using weak hashing algorithm
                                            `- [info] available since OpenSSH 2.5.0, Dropbear SSH 0.47
(mac) hmac-md5-96                           -- [fail] removed (in server) since OpenSSH 6.7, unsafe algorithm
                                            `- [warn] disabled (in client) since OpenSSH 7.2, legacy algorithm
                                            `- [warn] using encrypt-and-MAC mode
                                            `- [warn] using weak hashing algorithm
                                            `- [info] available since OpenSSH 2.5.0

# algorithm recommendations (for OpenSSH 5.9)
(rec) -diffie-hellman-group1-sha1           -- kex algorithm to remove
(rec) -diffie-hellman-group14-sha1          -- kex algorithm to remove
(rec) -diffie-hellman-group-exchange-sha1   -- kex algorithm to remove
(rec) -ecdh-sha2-nistp256                   -- kex algorithm to remove
(rec) -ecdh-sha2-nistp384                   -- kex algorithm to remove
(rec) -ecdh-sha2-nistp521                   -- kex algorithm to remove
(rec) -3des-cbc                             -- enc algorithm to remove
(rec) -blowfish-cbc                         -- enc algorithm to remove
(rec) -arcfour128                           -- enc algorithm to remove
(rec) -arcfour256                           -- enc algorithm to remove
(rec) -aes128-cbc                           -- enc algorithm to remove
(rec) -aes192-cbc                           -- enc algorithm to remove
(rec) -aes256-cbc                           -- enc algorithm to remove
(rec) -hmac-sha1                            -- mac algorithm to remove
(rec) -hmac-sha1-96                         -- mac algorithm to remove
(rec) -hmac-md5                             -- mac algorithm to remove
(rec) -hmac-md5-96                          -- mac algorithm to remove
```

ssh-audit AFTER:
```
$ python3 ./ssh-audit.py -p 2223 localhost
# general
(gen) banner: SSH-2.0-APACHE-SSHD-2.3.0
(gen) compatibility: OpenSSH 7.3+, Dropbear SSH 2016.73+
(gen) compression: disabled

# key exchange algorithms
(kex) ecdh-sha2-nistp521             -- [fail] using weak elliptic curves
                                     `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
(kex) ecdh-sha2-nistp384             -- [fail] using weak elliptic curves
                                     `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
(kex) ecdh-sha2-nistp256             -- [fail] using weak elliptic curves
                                     `- [info] available since OpenSSH 5.7, Dropbear SSH 2013.62
(kex) diffie-hellman-group14-sha256  -- [info] available since OpenSSH 7.3, Dropbear SSH 2016.73
(kex) diffie-hellman-group16-sha512  -- [info] available since OpenSSH 7.3, Dropbear SSH 2016.73
(kex) diffie-hellman-group18-sha512  -- [info] available since OpenSSH 7.3

# host-key algorithms
(key) rsa-sha2-512                   -- [info] available since OpenSSH 7.2
(key) rsa-sha2-256                   -- [info] available since OpenSSH 7.2
(key) ssh-rsa                        -- [info] available since OpenSSH 2.5.0, Dropbear SSH 0.28

# encryption algorithms (ciphers)
(enc) aes128-ctr                     -- [info] available since OpenSSH 3.7, Dropbear SSH 0.52
(enc) aes192-ctr                     -- [info] available since OpenSSH 3.7
(enc) aes256-ctr                     -- [info] available since OpenSSH 3.7, Dropbear SSH 0.52

# message authentication code algorithms
(mac) hmac-sha2-256                  -- [warn] using encrypt-and-MAC mode
                                     `- [info] available since OpenSSH 5.9, Dropbear SSH 2013.56
(mac) hmac-sha2-512                  -- [warn] using encrypt-and-MAC mode
                                     `- [info] available since OpenSSH 5.9, Dropbear SSH 2013.56

# algorithm recommendations (for OpenSSH 7.3)
(rec) -ecdh-sha2-nistp256            -- kex algorithm to remove
(rec) -ecdh-sha2-nistp384            -- kex algorithm to remove
(rec) -ecdh-sha2-nistp521            -- kex algorithm to remove
(rec) +curve25519-sha256@libssh.org  -- kex algorithm to append
(rec) +ssh-ed25519                   -- key algorithm to append
(rec) +aes128-gcm@openssh.com        -- enc algorithm to append
(rec) +aes256-gcm@openssh.com        -- enc algorithm to append
(rec) +chacha20-poly1305@openssh.com -- enc algorithm to append
(rec) -hmac-sha2-256                 -- mac algorithm to remove
(rec) -hmac-sha2-512                 -- mac algorithm to remove
(rec) +hmac-sha2-256-etm@openssh.com -- mac algorithm to append
(rec) +hmac-sha2-512-etm@openssh.com -- mac algorithm to append
(rec) +umac-128-etm@openssh.com      -- mac algorithm to append
``