### PR TITLE
CORDA-3520: Introduce DisconnectPlugin for SSH disconnect handling

### DIFF
--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/CRaSHCommandFactory.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/CRaSHCommandFactory.java
@@ -20,6 +20,7 @@ package org.crsh.ssh.term;
 
 import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
+import org.crsh.plugin.PluginContext;
 import org.crsh.shell.ShellFactory;
 
 import java.nio.charset.Charset;
@@ -32,9 +33,13 @@ public class CRaSHCommandFactory implements org.apache.sshd.server.shell.ShellFa
   /** . */
   final Charset encoding;
 
-  public CRaSHCommandFactory(ShellFactory shellFactory, Charset encoding) {
+  /** . */
+  final PluginContext pluginContext;
+
+  public CRaSHCommandFactory(ShellFactory shellFactory, Charset encoding, PluginContext pluginContext) {
     this.shellFactory = shellFactory;
     this.encoding = encoding;
+    this.pluginContext = pluginContext;
   }
 
   @Override

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
@@ -146,7 +146,7 @@ public class SSHLifeCycle {
         server.getProperties().put(ServerFactoryManager.AUTH_TIMEOUT, String.valueOf(this.authTimeout));
       }
 
-      server.setShellFactory(new CRaSHCommandFactory(factory, encoding));
+      server.setShellFactory(new CRaSHCommandFactory(factory, encoding, context));
       server.setCommandFactory(new SCPCommandFactory(context));
       server.setKeyPairProvider(keyPairProvider);
 

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/inline/SSHInlineCommand.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/inline/SSHInlineCommand.java
@@ -12,6 +12,7 @@ import org.crsh.shell.ShellResponse;
 import org.crsh.ssh.term.AbstractCommand;
 import org.crsh.ssh.term.SSHContext;
 import org.crsh.ssh.term.SSHLifeCycle;
+import org.crsh.auth.DisconnectPlugin;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -54,7 +55,15 @@ public class SSHInlineCommand extends AbstractCommand implements Runnable {
     thread.start();
   }
 
+  // Called only for SSH clients using <command> option, i.e. without interactive shell.
   public void destroy(ChannelSession channel) {
+    DisconnectPlugin disconnectHandler = pluginContext.getPlugin(DisconnectPlugin.class);
+    if (disconnectHandler != null) {
+      final String userName = session.getAttribute(SSHLifeCycle.USERNAME);
+      AuthInfo authInfo = session.getAttribute(SSHLifeCycle.AUTH_INFO);
+      disconnectHandler.onDisconnect(userName, authInfo);
+      log.info("Session " + userName + "@" + session.getIoSession().getRemoteAddress() + " disconnected");
+    }
     thread.interrupt();
   }
 

--- a/connectors/ssh/src/test/java/org/crsh/ssh/DisconnectTest.java
+++ b/connectors/ssh/src/test/java/org/crsh/ssh/DisconnectTest.java
@@ -1,0 +1,98 @@
+package org.crsh.ssh;
+
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.session.ClientSession;
+import org.crsh.auth.AuthInfo;
+import org.crsh.auth.AuthenticationPlugin;
+import org.crsh.auth.SimpleAuthenticationPlugin;
+import org.crsh.plugin.CRaSHPlugin;
+import org.crsh.shell.impl.command.CRaSHShellFactory;
+import org.crsh.auth.DisconnectPlugin;
+import org.crsh.ssh.term.inline.SSHInlinePlugin;
+import org.crsh.util.Utils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import test.plugin.TestPluginLifeCycle;
+
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DisconnectTest {
+    private TestPluginLifeCycle lifeCycle;
+
+    private CountDownLatch disconnectLatch = new CountDownLatch(1);
+
+    private int port;
+
+    private static final AtomicInteger PORTS = new AtomicInteger(2000);
+
+    public static class TestDisconnectHandler extends CRaSHPlugin<DisconnectPlugin> implements DisconnectPlugin {
+        private final CountDownLatch latch;
+
+        public TestDisconnectHandler(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public void onDisconnect(String userName, AuthInfo authInfo) {
+            latch.countDown();
+        }
+
+        @Override
+        public DisconnectPlugin getImplementation() {
+            return this;
+        }
+    }
+    @Before
+    public void setUp() throws Exception {
+        port = PORTS.getAndIncrement();
+        SimpleAuthenticationPlugin auth = new SimpleAuthenticationPlugin();
+        lifeCycle = new TestPluginLifeCycle(new SSHPlugin(), auth, new CRaSHShellFactory(), new SSHInlinePlugin(), new TestDisconnectHandler(disconnectLatch));
+        lifeCycle.setProperty(SSHPlugin.SSH_PORT, port);
+        lifeCycle.setProperty(SSHPlugin.SSH_ENCODING, Utils.UTF_8);
+        lifeCycle.setProperty(AuthenticationPlugin.AUTH, Arrays.asList(auth.getName()));
+        lifeCycle.setProperty(SimpleAuthenticationPlugin.SIMPLE_USERNAME, "admin");
+        lifeCycle.setProperty(SimpleAuthenticationPlugin.SIMPLE_PASSWORD, "admin");
+        lifeCycle.start();
+    }
+
+    @After
+    public final void tearDown() {
+        lifeCycle.stop();
+    }
+
+    @Test
+    public void testDisconnectOnExit() throws Exception {
+        SSHClient client = new SSHClient(port).connect();
+        client.write("exit\n").flush();
+        disconnectLatch.await(4L, TimeUnit.SECONDS);
+        client.close();
+    }
+
+    @Test
+    public void testDisconnectOnEOT() throws Exception {
+        SSHClient client = new SSHClient(port).connect();
+        client.write("\004").flush();
+        disconnectLatch.await(4L, TimeUnit.SECONDS);
+        client.close();
+    }
+
+    @Test
+    public void testDisconnectWithRemoteCommand() throws Exception {
+        SshClient client = SshClient.setUpDefaultClient();
+        client.start();
+
+        ClientSession session = client.connect("admin", "localhost", port).verify(4L, TimeUnit.SECONDS).getSession();
+        session.addPasswordIdentity("admin");
+        session.auth().verify(4L, TimeUnit.SECONDS);
+
+        session.executeRemoteCommand("help");
+        disconnectLatch.await(4L, TimeUnit.SECONDS);
+
+        session.close(false);
+        client.stop();
+    }
+}

--- a/shell/src/main/java/org/crsh/auth/DisconnectPlugin.java
+++ b/shell/src/main/java/org/crsh/auth/DisconnectPlugin.java
@@ -1,0 +1,8 @@
+package org.crsh.auth;
+
+/**
+ * Plugin for SSH session disconnect handling.
+ */
+public interface DisconnectPlugin {
+    void onDisconnect(String userName, AuthInfo authInfo);
+}

--- a/shell/src/main/java/org/crsh/console/jline/JLineProcessor.java
+++ b/shell/src/main/java/org/crsh/console/jline/JLineProcessor.java
@@ -30,6 +30,7 @@ import org.crsh.shell.Shell;
 import org.crsh.text.Style;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.PrintStream;
 import java.util.Stack;
 import java.util.concurrent.CountDownLatch;
@@ -208,6 +209,11 @@ public class JLineProcessor implements Runnable, ConsoleDriver {
         } else {
           System.out.println("No operation: " + o);
         }
+      }
+      catch (InterruptedIOException e) {
+        // Suppress warning for "Interrupted at cycle #0 while waiting for data to become available"
+        logger.log(Level.FINE, e.getMessage(), e);
+        return;
       }
       catch (IOException e) {
         logger.log(Level.WARNING, e.getMessage(), e);


### PR DESCRIPTION
To avoid memory leaks on SSH session disconnect, we need to hook into disconnect handling.
It's implemented via newly introduced ``DisconnectPlugin``.

There are 2 different code paths for interactive shell and remote command executions - both are addressed.

Introduced log line for disconnect:
```
[INFO ] 2020-01-17T16:40:22,621Z [sshd-SshServer[4028aab2](port=2222)-nio2-thread-13] term.CRaSHCommand. - Session test@/127.0.0.1:50218 disconnected
```

Also, removed the following warning periodically appearing on CRaSH session disconnect (i.e. moved to debug):
```
[WARN ] 2020-01-17T16:40:22,622Z [CRaSH] jline.JLineProcessor. - Interrupted at cycle #0 while waiting for data to become available [errorCode=19a542j, moreInformationAt=https://errors.corda.net/OS/4.4-SNAPSHOT/19a542j]
java.io.InterruptedIOException: Interrupted at cycle #0 while waiting for data to become available
        at org.apache.sshd.common.channel.ChannelPipedInputStream.read(ChannelPipedInputStream.java:142) ~[sshd-core-2.3.0.jar:2.3.0]
        at org.apache.sshd.common.channel.ChannelPipedInputStream.read(ChannelPipedInputStream.java:100) ~[sshd-core-2.3.0.jar:2.3.0]
        at org.crsh.console.jline.internal.NonBlockingInputStream.read(NonBlockingInputStream.java:166) ~[crash.shell-1.7.2-SNAPSHOT.jar:?]
        at org.crsh.console.jline.internal.NonBlockingInputStream.read(NonBlockingInputStream.java:135) ~[crash.shell-1.7.2-SNAPSHOT.jar:?]
        at org.crsh.console.jline.internal.NonBlockingInputStream.read(NonBlockingInputStream.java:243) ~[crash.shell-1.7.2-SNAPSHOT.jar:?]
        at org.crsh.console.jline.internal.InputStreamReader.read(InputStreamReader.java:257) ~[crash.shell-1.7.2-SNAPSHOT.jar:?]
        at org.crsh.console.jline.internal.InputStreamReader.read(InputStreamReader.java:194) ~[crash.shell-1.7.2-SNAPSHOT.jar:?]
        at org.crsh.console.jline.console.ConsoleReader.readCharacter(ConsoleReader.java:2147) ~[crash.shell-1.7.2-SNAPSHOT.jar:?]
        at org.crsh.console.jline.console.ConsoleReader.readCharacter(ConsoleReader.java:2137) ~[crash.shell-1.7.2-SNAPSHOT.jar:?]
        at org.crsh.console.jline.JLineProcessor.run(JLineProcessor.java:114) ~[crash.shell-1.7.2-SNAPSHOT.jar:?]
        at org.crsh.ssh.term.CRaSHCommand.run(CRaSHCommand.java:125) ~[crash.connectors.ssh-1.7.2-SNAPSHOT.jar:?]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
Caused by: java.lang.InterruptedException
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.reportInterruptAfterWait(AbstractQueuedSynchronizer.java:2014) ~[?:1.8.0_212]
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2048) ~[?:1.8.0_212]
        at org.apache.sshd.common.channel.ChannelPipedInputStream.read(ChannelPipedInputStream.java:139) ~[sshd-core-2.3.0.jar:2.3.0]
        ... 11 more
```