### PR TITLE
ENT-5003 Fix Dashboard command in CRaSH 

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.cli</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH CLI</name>
   <description>The CRaSH command line interface module</description>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Connectors</name>
 

--- a/connectors/ssh/pom.xml
+++ b/connectors/ssh/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.connectors</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors.ssh</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Connectors - SSH</name>
   <description>The CRaSH SSH connector</description>

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/CRaSHCommand.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/CRaSHCommand.java
@@ -21,6 +21,7 @@ package org.crsh.ssh.term;
 import org.apache.sshd.server.channel.ChannelSession;
 import org.crsh.auth.DisconnectPlugin;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.console.jline.Terminal;
 import org.crsh.console.jline.console.ConsoleReader;
 import org.apache.sshd.server.Environment;
@@ -107,7 +108,7 @@ public class CRaSHCommand extends AbstractCommand implements Runnable, Terminal 
 
       boolean safeUser = !isUserUnsafe(user.getName());
 
-      ShellSafety shellSafety = new ShellSafety();
+      ShellSafety shellSafety = ShellSafetyFactory.getCurrentThreadShellSafety();
       shellSafety.setSafeShell(safeUser);
       shellSafety.setInternal(isInternalSSH());
       shellSafety.setSSH(true);

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/inline/SSHInlineCommand.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/inline/SSHInlineCommand.java
@@ -4,6 +4,7 @@ import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.channel.ChannelSession;
 import org.crsh.auth.AuthInfo;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.plugin.PluginContext;
 import org.crsh.shell.Shell;
 import org.crsh.shell.ShellFactory;
@@ -79,7 +80,7 @@ public class SSHInlineCommand extends AbstractCommand implements Runnable {
         return userName;
       }
     };
-    Shell shell = pluginContext.getPlugin(ShellFactory.class).create(user, authInfo, new ShellSafety());
+    Shell shell = pluginContext.getPlugin(ShellFactory.class).create(user, authInfo, ShellSafetyFactory.getCurrentThreadShellSafety());
     ShellProcess shellProcess = shell.createProcess(command);
 
     //

--- a/connectors/telnet/pom.xml
+++ b/connectors/telnet/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.connectors</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors.telnet</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Connectors - Telnet</name>
   <description>The CRaSH Telnet connector</description>

--- a/connectors/telnet/src/main/java/org/crsh/telnet/term/processor/ProcessorIOHandler.java
+++ b/connectors/telnet/src/main/java/org/crsh/telnet/term/processor/ProcessorIOHandler.java
@@ -21,6 +21,7 @@ package org.crsh.telnet.term.processor;
 
 import org.crsh.auth.AuthInfo;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.plugin.CRaSHPlugin;
 import org.crsh.shell.Shell;
 import org.crsh.shell.ShellFactory;
@@ -50,7 +51,7 @@ public class ProcessorIOHandler extends CRaSHPlugin<TermIOHandler> implements Te
   }
 
   public void handle(final TermIO io, Principal user, AuthInfo authInfo) {
-    Shell shell = factory.create(user, authInfo, new ShellSafety());
+    Shell shell = factory.create(user, authInfo, ShellSafetyFactory.getCurrentThreadShellSafety());
     ConsoleTerm term = new ConsoleTerm(io);
     Processor processor = new Processor(term, shell);
     processor.addListener(io);

--- a/connectors/web/pom.xml
+++ b/connectors/web/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.connectors</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors.web</artifactId>
   <packaging>war</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Connectors - Web</name>
   <description>The CRaSH Web connector</description>

--- a/connectors/web/src/main/java/org/crsh/web/servlet/CRaSHConnector.java
+++ b/connectors/web/src/main/java/org/crsh/web/servlet/CRaSHConnector.java
@@ -25,6 +25,7 @@ import org.crsh.cli.impl.Delimiter;
 import org.crsh.cli.impl.completion.CompletionMatch;
 import org.crsh.cli.spi.Completion;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.keyboard.KeyType;
 import org.crsh.plugin.PluginContext;
 import org.crsh.plugin.WebPluginLifeCycle;
@@ -87,7 +88,7 @@ public class CRaSHConnector {
           log.fine("Using shell " + context);
           ShellFactory factory = context.getPlugin(ShellFactory.class);
           Principal user = wsSession.getUserPrincipal();
-          Shell shell = factory.create(user, null, new ShellSafety());
+          Shell shell = factory.create(user, null, ShellSafetyFactory.getCurrentThreadShellSafety());
           CRaSHSession session = new CRaSHSession(wsSession, shell);
           sessions.put(wsSession.getId(), session);
           log.fine("Established session " + wsSession.getId());

--- a/distrib/pom.xml
+++ b/distrib/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.distrib</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Distrib</name>
   <description>The CRaSH distribution</description>

--- a/doc/api/pom.xml
+++ b/doc/api/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>crash.doc</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc.api</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Doc API</name>
   <description>The CRaSH API documentation</description>

--- a/doc/cookbook/pom.xml
+++ b/doc/cookbook/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>crash.doc</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc.cookbook</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Doc Cookbook</name>
   <description>The CRaSH cookbook documentation</description>

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Doc</name>
 

--- a/doc/reference/pom.xml
+++ b/doc/reference/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>crash.doc</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc.reference</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Doc Reference</name>
   <description>The CRaSH reference documentation</description>

--- a/embed/pom.xml
+++ b/embed/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.embed</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Embed</name>
 

--- a/embed/spring/pom.xml
+++ b/embed/spring/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.embed</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.embed.spring</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Embed Spring</name>
   <description>The CRaSH Spring integration module</description>

--- a/embed/spring/src/test/java/org/crsh/spring/SpringTestCase.java
+++ b/embed/spring/src/test/java/org/crsh/spring/SpringTestCase.java
@@ -22,6 +22,7 @@ package org.crsh.spring;
 import junit.framework.Assert;
 import junit.framework.TestCase;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import test.shell.base.BaseProcessContext;
 import org.crsh.shell.Shell;
 import org.crsh.shell.ShellFactory;
@@ -48,7 +49,7 @@ public class SpringTestCase extends TestCase {
 
     // Test a bit
     ShellFactory factory = bootstrap.getContext().getPlugin(ShellFactory.class);
-    Shell shell = factory.create(null, null, new ShellSafety());
+    Shell shell = factory.create(null, null, ShellSafetyFactory.getCurrentThreadShellSafety());
     assertNotNull(shell);
     ShellProcess process = shell.createProcess("foo_cmd");
     assertNotNull(process);

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.packaging</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Packaging</name>
   <description>The CRaSH packaging module</description>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.plugins</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Plugins</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.crashub</groupId>
   <artifactId>crash.parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
   <!-- To update project version run the following:
     mvn versions:set -DnewVersion=<new version>
     mvn versions:commit # Necessary to remove the backup file pom.xml
@@ -116,12 +116,12 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.cli</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.cli</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -129,25 +129,25 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <type>jar</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <type>test-jar</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <classifier>standalone</classifier>
       </dependency>
 
@@ -155,18 +155,18 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.telnet</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.telnet</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.telnet</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <classifier>standalone</classifier>
       </dependency>
 
@@ -174,18 +174,18 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.ssh</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.ssh</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.ssh</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <classifier>standalone</classifier>
       </dependency>
 
@@ -193,12 +193,12 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.web</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.web</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -206,12 +206,12 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.embed.spring</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.embed.spring</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -219,32 +219,32 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <type>war</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <type>war</type>
         <classifier>spring</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <type>zip</type>
         <classifier>mule-app</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <type>tar.gz</type>
       </dependency>
 
@@ -280,7 +280,7 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.api</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <classifier>javadoc</classifier>
       </dependency>
 
@@ -288,13 +288,13 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.reference</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <type>pdf</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.reference</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <classifier>html</classifier>
         <type>zip</type>
       </dependency>
@@ -303,13 +303,13 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.cookbook</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <type>pdf</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.cookbook</artifactId>
-        <version>1.7.3-SNAPSHOT</version>
+        <version>1.7.4-SNAPSHOT</version>
         <classifier>html</classifier>
         <type>zip</type>
       </dependency>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.shell</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.3-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
 
   <name>CRaSH Shell</name>
   <description>The Shell module</description>

--- a/shell/src/main/java/org/crsh/command/ShellSafetyFactory.java
+++ b/shell/src/main/java/org/crsh/command/ShellSafetyFactory.java
@@ -1,0 +1,27 @@
+package org.crsh.command;
+
+
+import java.util.HashMap;
+
+public class ShellSafetyFactory {
+    static private HashMap<Long, ShellSafety> safetyByThread = new HashMap<Long, ShellSafety>();
+    static public ShellSafety getCurrentThreadShellSafety() {
+        long threadId = Thread.currentThread().getId();
+        synchronized (safetyByThread) {
+            if (safetyByThread.containsKey(threadId)) {
+                return safetyByThread.get(threadId);
+            }
+        }
+
+        ShellSafety ret = new ShellSafety();
+        ret.setSafeShell(false);
+        return ret;
+    }
+
+    static public void registerShellSafetyForThread(ShellSafety shellSafety) {
+        long threadId = Thread.currentThread().getId();
+        synchronized (safetyByThread) {
+            safetyByThread.put(threadId, shellSafety);
+        }
+    }
+}

--- a/shell/src/main/java/org/crsh/lang/impl/groovy/GroovyCompiler.java
+++ b/shell/src/main/java/org/crsh/lang/impl/groovy/GroovyCompiler.java
@@ -32,6 +32,7 @@ import org.crsh.cli.Usage;
 import org.crsh.cli.impl.descriptor.IntrospectionException;
 import org.crsh.command.BaseCommand;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.lang.impl.java.ClassShellCommand;
 import org.crsh.shell.ErrorKind;
 import org.crsh.shell.impl.command.ShellSession;
@@ -199,7 +200,7 @@ public class GroovyCompiler implements org.crsh.lang.spi.Compiler {
   }
 
   private <C extends BaseCommand> ClassShellCommand<C> make(Class<C> clazz) throws IntrospectionException {
-    return new ClassShellCommand<C>(clazz, new ShellSafety());
+    return new ClassShellCommand<C>(clazz, ShellSafetyFactory.getCurrentThreadShellSafety());
   }
 
   private <C extends GroovyScriptCommand> GroovyScriptShellCommand<C> make2(Class<C> clazz) throws IntrospectionException {

--- a/shell/src/main/java/org/crsh/lang/impl/groovy/GroovyRepl.java
+++ b/shell/src/main/java/org/crsh/lang/impl/groovy/GroovyRepl.java
@@ -24,6 +24,7 @@ import org.crsh.cli.impl.completion.CompletionMatch;
 import org.crsh.cli.spi.Completion;
 import org.crsh.command.CommandContext;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.lang.spi.Language;
 import org.crsh.lang.spi.ReplResponse;
 import org.crsh.shell.ErrorKind;
@@ -89,7 +90,7 @@ public class GroovyRepl implements Repl {
         this.consumer = (CommandContext<Object>)consumer;
         GroovyShell shell = GroovyCompiler.getGroovyShell(session);
         ShellBinding binding = (ShellBinding)shell.getContext();
-        binding.setCurrent(new InvocationContextImpl<Object>(this.consumer, new ShellSafety()));
+        binding.setCurrent(new InvocationContextImpl<Object>(this.consumer, ShellSafetyFactory.getCurrentThreadShellSafety()));
         Object o;
         try {
           o = shell.evaluate(request);

--- a/shell/src/main/java/org/crsh/lang/impl/groovy/Helper.java
+++ b/shell/src/main/java/org/crsh/lang/impl/groovy/Helper.java
@@ -24,6 +24,7 @@ import org.codehaus.groovy.runtime.InvokerInvocationException;
 import org.crsh.command.InvocationContext;
 import org.crsh.command.RuntimeContext;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.lang.impl.groovy.closure.PipeLineClosure;
 import org.crsh.shell.Shell;
 import org.crsh.shell.impl.command.CRaSH;
@@ -67,7 +68,7 @@ public class Helper {
     CRaSH crash = (CRaSH)context.getSession().get("crash");
     if (crash != null) {
       try {
-        Command<?> cmd = crash.getCommandSafetyCheck(property, new ShellSafety());
+        Command<?> cmd = crash.getCommandSafetyCheck(property, ShellSafetyFactory.getCurrentThreadShellSafety());
         if (cmd != null) {
           return new PipeLineClosure(context, property, cmd);
         } else {
@@ -86,7 +87,7 @@ public class Helper {
     if (crash != null) {
       final Command<?> cmd;
       try {
-        cmd = crash.getCommandSafetyCheck(name, new ShellSafety());
+        cmd = crash.getCommandSafetyCheck(name, ShellSafetyFactory.getCurrentThreadShellSafety());
       }
       catch (CommandException ce) {
         throw new InvokerInvocationException(ce);

--- a/shell/src/main/java/org/crsh/lang/impl/groovy/ShellBinding.java
+++ b/shell/src/main/java/org/crsh/lang/impl/groovy/ShellBinding.java
@@ -22,6 +22,7 @@ import groovy.lang.Binding;
 import org.crsh.command.CommandContext;
 import org.crsh.command.InvocationContext;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.shell.impl.command.AbstractInvocationContext;
 import org.crsh.shell.impl.command.spi.CommandInvoker;
 import org.crsh.text.RenderPrintWriter;
@@ -64,7 +65,7 @@ class ShellBinding extends Binding {
 
     @Override
     public ShellSafety getShellSafety() {
-      return new ShellSafety();
+      return ShellSafetyFactory.getCurrentThreadShellSafety();
     }
 
     public CommandInvoker<?, ?> resolve(String s) throws CommandException {
@@ -217,7 +218,7 @@ class ShellBinding extends Binding {
         try {
           Command<?> cmd = session.getCommand(name);
           if (cmd != null) {
-            return new PipeLineClosure(new InvocationContextImpl<Object>(proxy, new ShellSafety()), name, cmd);
+            return new PipeLineClosure(new InvocationContextImpl<Object>(proxy, ShellSafetyFactory.getCurrentThreadShellSafety()), name, cmd);
           }
         } catch (CommandException ignore) {
           // Really ?

--- a/shell/src/main/java/org/crsh/lang/impl/groovy/closure/ClosureDelegate.java
+++ b/shell/src/main/java/org/crsh/lang/impl/groovy/closure/ClosureDelegate.java
@@ -22,6 +22,7 @@ import groovy.lang.GroovyObjectSupport;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.crsh.command.CommandContext;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.lang.impl.groovy.Helper;
 import org.crsh.shell.Shell;
 import org.crsh.shell.impl.command.InvocationContextImpl;
@@ -50,7 +51,7 @@ class ClosureDelegate extends GroovyObjectSupport {
     if ("context".equals(property)) {
       return context;
     } else {
-      Object value = Helper.resolveProperty(new InvocationContextImpl(context, new ShellSafety()), property);
+      Object value = Helper.resolveProperty(new InvocationContextImpl(context, ShellSafetyFactory.getCurrentThreadShellSafety()), property);
       if (value != null) {
         return value;
       } else {
@@ -62,7 +63,7 @@ class ClosureDelegate extends GroovyObjectSupport {
 
   @Override
   public Object invokeMethod(String name, Object args) {
-    SafeCallable runnable = Helper.resolveMethodInvocation(new InvocationContextImpl(context, new ShellSafety()), name, args);
+    SafeCallable runnable = Helper.resolveMethodInvocation(new InvocationContextImpl(context, ShellSafetyFactory.getCurrentThreadShellSafety()), name, args);
     if (runnable != null) {
       return runnable.call();
     } else {

--- a/shell/src/main/java/org/crsh/lang/impl/groovy/closure/PipeLineInvocationContext.java
+++ b/shell/src/main/java/org/crsh/lang/impl/groovy/closure/PipeLineInvocationContext.java
@@ -20,6 +20,7 @@
 package org.crsh.lang.impl.groovy.closure;
 
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.shell.impl.command.AbstractInvocationContext;
 import org.crsh.shell.impl.command.spi.CommandException;
 import org.crsh.text.Screenable;
@@ -44,7 +45,7 @@ class PipeLineInvocationContext extends AbstractInvocationContext<Object> {
 
   @Override
   public ShellSafety getShellSafety() {
-    return new ShellSafety();
+    return ShellSafetyFactory.getCurrentThreadShellSafety();
   }
 
   public CommandInvoker<?, ?> resolve(String s) throws CommandException {

--- a/shell/src/main/java/org/crsh/lang/impl/groovy/command/GroovyScriptShellCommand.java
+++ b/shell/src/main/java/org/crsh/lang/impl/groovy/command/GroovyScriptShellCommand.java
@@ -29,6 +29,7 @@ import org.crsh.cli.impl.lang.Instance;
 import org.crsh.cli.spi.Completer;
 import org.crsh.command.CommandContext;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.groovy.GroovyCommand;
 import org.crsh.shell.ErrorKind;
 import org.crsh.shell.impl.command.spi.CommandException;
@@ -137,7 +138,7 @@ public class GroovyScriptShellCommand<T extends GroovyScriptCommand> extends Com
       public void open(CommandContext<? super Object> consumer) throws IOException, CommandException {
 
         // Set the context
-        context = new InvocationContextImpl<Object>((CommandContext<Object>)consumer, new ShellSafety());
+        context = new InvocationContextImpl<Object>((CommandContext<Object>)consumer, ShellSafetyFactory.getCurrentThreadShellSafety());
 
         // Set up current binding
         Binding binding = new Binding(consumer.getSession());

--- a/shell/src/main/java/org/crsh/lang/impl/java/JavaCompiler.java
+++ b/shell/src/main/java/org/crsh/lang/impl/java/JavaCompiler.java
@@ -20,7 +20,7 @@ package org.crsh.lang.impl.java;
 
 import org.crsh.cli.descriptor.Format;
 import org.crsh.cli.impl.descriptor.IntrospectionException;
-import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.shell.ErrorKind;
 import org.crsh.shell.impl.command.spi.CommandException;
 import org.crsh.shell.impl.command.ShellSession;
@@ -74,7 +74,7 @@ public class JavaCompiler implements org.crsh.lang.spi.Compiler {
           Class<?> clazz = loader.loadClass(classFile.getClassName());
           final ClassShellCommand command;
           try {
-            command = new ClassShellCommand(clazz, new ShellSafety());
+            command = new ClassShellCommand(clazz, ShellSafetyFactory.getCurrentThreadShellSafety());
           }
           catch (IntrospectionException e) {
             throw new CommandException(ErrorKind.INTERNAL, "Invalid cli annotations", e);

--- a/shell/src/main/java/org/crsh/lang/impl/java/PipeCommandMatch.java
+++ b/shell/src/main/java/org/crsh/lang/impl/java/PipeCommandMatch.java
@@ -107,7 +107,7 @@ class PipeCommandMatch<T extends BaseCommand, C, P, PC extends Pipe<C, P>> exten
       public void open2(final CommandContext<P> consumer) throws CommandException {
 
         //
-        invocationContext = new InvocationContextImpl<P>(consumer, new ShellSafety());
+        invocationContext = new InvocationContextImpl<P>(consumer, ShellSafetyFactory.getCurrentThreadShellSafety());
 
         // Push context
         command.pushContext(invocationContext);

--- a/shell/src/main/java/org/crsh/shell/impl/command/CRaSH.java
+++ b/shell/src/main/java/org/crsh/shell/impl/command/CRaSH.java
@@ -22,6 +22,7 @@ package org.crsh.shell.impl.command;
 //import crash.commands.base.system;
 import org.crsh.auth.AuthInfo;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.lang.LanguageCommandResolver;
 import org.crsh.lang.spi.Language;
 import org.crsh.shell.impl.command.spi.Command;
@@ -103,7 +104,7 @@ public class CRaSH {
    * @throws NullPointerException if the name argument is null
    */
   public Command<?> getCommand(String name) throws CommandException, NullPointerException {
-    return getCommandSafetyCheck(name, new ShellSafety());
+    return getCommandSafetyCheck(name, ShellSafetyFactory.getCurrentThreadShellSafety());
   }
   public Command<?> getCommandSafetyCheck(String name, ShellSafety shellSafety) throws CommandException, NullPointerException {
     if (name == null) {
@@ -124,7 +125,7 @@ public class CRaSH {
   }
 
   public Iterable<Map.Entry<String, String>> getCommands() {
-    return getCommandsSafetyCheck(new ShellSafety());
+    return getCommandsSafetyCheck(ShellSafetyFactory.getCurrentThreadShellSafety());
   }
 
   public Iterable<Map.Entry<String, String>> getCommandsSafetyCheck(ShellSafety shellSafety) {

--- a/shell/src/main/java/org/crsh/shell/impl/command/CRaSHSession.java
+++ b/shell/src/main/java/org/crsh/shell/impl/command/CRaSHSession.java
@@ -21,6 +21,7 @@ package org.crsh.shell.impl.command;
 import org.crsh.auth.AuthInfo;
 import org.crsh.cli.impl.completion.CompletionMatch;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.lang.spi.Compiler;
 import org.crsh.lang.spi.Language;
 import org.crsh.lang.spi.Repl;
@@ -72,6 +73,7 @@ public class CRaSHSession extends HashMap<String, Object> implements Shell, Clos
     this.user = user;
     this.authInfo = authInfo;
     this.shellSafety = shellSafety;
+    ShellSafetyFactory.registerShellSafetyForThread(this.shellSafety);
 
     //
     ClassLoader previous = setCRaSHLoader();

--- a/shell/src/main/java/org/crsh/shell/impl/command/ExternalResolver.java
+++ b/shell/src/main/java/org/crsh/shell/impl/command/ExternalResolver.java
@@ -7,6 +7,7 @@ import org.crsh.cli.descriptor.Format;
 import org.crsh.cli.impl.descriptor.IntrospectionException;
 import org.crsh.command.BaseCommand;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.lang.impl.java.ClassShellCommand;
 import org.crsh.lang.spi.CommandResolution;
 import org.crsh.shell.ErrorKind;
@@ -56,7 +57,7 @@ public class ExternalResolver implements CommandResolver
 		final String description;
 		try
 		{
-			shellCommand = new ClassShellCommand<C>(commandClass, new ShellSafety());
+			shellCommand = new ClassShellCommand<C>(commandClass, ShellSafetyFactory.getCurrentThreadShellSafety());
 			description = shellCommand.describe(commandClass.getSimpleName(), Format.DESCRIBE);
 		}
 		catch (IntrospectionException e)

--- a/shell/src/main/java/org/crsh/shell/impl/command/InvocationContextImpl.java
+++ b/shell/src/main/java/org/crsh/shell/impl/command/InvocationContextImpl.java
@@ -54,7 +54,7 @@ public final class InvocationContextImpl<P> extends AbstractInvocationContext<P>
 
   /** . */
   int status;
-  private ShellSafety shellSafety = new ShellSafety();
+  ShellSafety shellSafety = null;
 
   @Override
   public ShellSafety getShellSafety() {

--- a/shell/src/main/java/org/crsh/standalone/Agent.java
+++ b/shell/src/main/java/org/crsh/standalone/Agent.java
@@ -30,6 +30,7 @@ import org.crsh.cli.impl.invocation.InvocationMatcher;
 import org.crsh.cli.impl.lang.Instance;
 import org.crsh.cli.impl.lang.Util;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.shell.Shell;
 import org.crsh.shell.ShellFactory;
 import org.crsh.shell.impl.remoting.RemoteClient;
@@ -131,7 +132,7 @@ public class Agent {
     if (port != null) {
       try {
         ShellFactory factory = bootstrap.getContext().getPlugin(ShellFactory.class);
-        Shell shell = factory.create(null,null, new ShellSafety());
+        Shell shell = factory.create(null,null, ShellSafetyFactory.getCurrentThreadShellSafety());
         RemoteClient client = new RemoteClient(port, shell);
         log.log(Level.INFO, "Callback back remote on port " + port);
         client.connect();

--- a/shell/src/main/java/org/crsh/standalone/CRaSH.java
+++ b/shell/src/main/java/org/crsh/standalone/CRaSH.java
@@ -39,6 +39,7 @@ import org.crsh.cli.impl.lang.CommandFactory;
 import org.crsh.cli.impl.lang.Instance;
 import org.crsh.cli.impl.lang.Util;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.console.jline.JLineProcessor;
 import org.crsh.plugin.ResourceManager;
 import org.crsh.shell.Shell;
@@ -342,7 +343,7 @@ public class CRaSH {
       //
       if (interactive) {
         ShellFactory factory = bootstrap.getContext().getPlugin(ShellFactory.class);
-        ShellSafety shellSafety = new ShellSafety();
+        ShellSafety shellSafety = ShellSafetyFactory.getCurrentThreadShellSafety();
         shellSafety.setStandAlone(true);
         shell = factory.create(null, null, shellSafety);
       } else {

--- a/shell/src/main/java/org/crsh/text/ui/EvalElement.java
+++ b/shell/src/main/java/org/crsh/text/ui/EvalElement.java
@@ -21,6 +21,7 @@ package org.crsh.text.ui;
 
 import groovy.lang.Closure;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.groovy.GroovyCommand;
 import org.crsh.shell.Shell;
 import org.crsh.shell.impl.command.AbstractInvocationContext;
@@ -81,7 +82,7 @@ public class EvalElement extends Element {
 
       @Override
       public ShellSafety getShellSafety() {
-        return new ShellSafety();
+        return ShellSafetyFactory.getCurrentThreadShellSafety();
       }
 
       public CommandInvoker<?, ?> resolve(String s) throws CommandException {

--- a/shell/src/test/java/test/command/TestInvocationContext.java
+++ b/shell/src/test/java/test/command/TestInvocationContext.java
@@ -20,15 +20,12 @@
 package test.command;
 
 import org.crsh.cli.impl.descriptor.IntrospectionException;
-import org.crsh.command.BaseCommand;
-import org.crsh.command.CommandContext;
-import org.crsh.command.ShellSafety;
+import org.crsh.command.*;
 import org.crsh.shell.impl.command.spi.CommandException;
 import org.crsh.lang.impl.java.ClassShellCommand;
 import org.crsh.shell.impl.command.RuntimeContextImpl;
 import org.crsh.shell.impl.command.spi.Command;
 import org.crsh.shell.impl.command.spi.CommandInvoker;
-import org.crsh.command.ScriptException;
 import org.crsh.lang.impl.groovy.command.GroovyScriptCommand;
 import org.crsh.lang.impl.groovy.command.GroovyScriptShellCommand;
 import org.crsh.text.CLS;
@@ -157,7 +154,7 @@ public class TestInvocationContext<C> extends RuntimeContextImpl implements Comm
   }
 
   public <B extends BaseCommand> String execute(Class<B> commandClass, String... args) throws IntrospectionException, IOException, CommandException  {
-    return execute(new ClassShellCommand<B>(commandClass, new ShellSafety()), args);
+    return execute(new ClassShellCommand<B>(commandClass, ShellSafetyFactory.getCurrentThreadShellSafety()), args);
   }
 
   public <B extends GroovyScriptCommand> String execute2(Class<B> commandClass, String... args) throws IntrospectionException, IOException, UndeclaredThrowableException, CommandException {

--- a/shell/src/test/java/test/plugin/TestPluginLifeCycle.java
+++ b/shell/src/test/java/test/plugin/TestPluginLifeCycle.java
@@ -21,6 +21,7 @@ package test.plugin;
 
 import org.crsh.command.BaseCommand;
 import org.crsh.command.ShellSafety;
+import org.crsh.command.ShellSafetyFactory;
 import org.crsh.plugin.*;
 import org.crsh.shell.Shell;
 import org.crsh.shell.impl.command.CRaSH;
@@ -121,7 +122,7 @@ public class TestPluginLifeCycle extends PluginLifeCycle {
   }
 
   public Shell createShell() {
-    return crash.createSession(null, null, new ShellSafety());
+    return crash.createSession(null, null, ShellSafetyFactory.getCurrentThreadShellSafety());
   }
 }
 


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/ENT-5003

Safe/Unsafe mode Shell Safety is not propagated to sub-commands which are used to implement the Dashboard command in CRaSH.

Added thread level Shell Safety caching to address the issue.