### PR TITLE
ENT-6388: Upgrade version of `mina-core`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
       <dependency>
         <groupId>org.apache.mina</groupId>
         <artifactId>mina-core</artifactId>
-        <version>2.0.16</version>
+        <version>2.0.22</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
This is required to close off: CVE-2021-41973: ‘Apache MINA HTTP listener DoS’