### PR TITLE
ENT-6470: Add Artifactory publishing logic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline {
                 expression { return isMainBranch() }
             }
             steps {
-                sh "mvn deploy -s settings.xml -DskipTests"
+                sh "mvn deploy -B -s settings.xml -DskipTests"
             }
         }
 
@@ -80,7 +80,7 @@ pipeline {
                 expression { return isReleaseTag() }
             }
             steps {
-                sh "mvn deploy -s settings.xml -DskipTests"
+                sh "mvn deploy -B -s settings.xml -DskipTests"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,95 @@
+#!groovy
+
+/**
+ * Kill already started job.
+ * Assume new commit takes precendence and results from previous
+ * unfinished builds are not required.
+ * This feature doesn't play well with disableConcurrentBuilds() option
+ */
+@Library('corda-shared-build-pipeline-steps')
+import static com.r3.build.BuildControl.killAllExistingBuildsForJob
+
+killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
+
+pipeline {
+    agent { label 'standard' }
+
+    options {
+        timestamps()
+        timeout(time: 1, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
+    }
+
+
+    tools {
+        maven "maven"
+    }
+
+    parameters {
+        booleanParam(name: "TESTS",
+                description: "Skip tests",
+                defaultValue: false)
+    }
+
+    triggers {
+        pollSCM "* * * * *"
+    }
+
+    environment {
+        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
+        CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
+        CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
+        JAVA_HOME = "/usr/lib/jvm/java-1.8.0-amazon-corretto"
+    }
+
+    stages {
+
+        stage('Build ') {
+            steps {
+                sh "mvn -B install -DskipTests"
+
+            }
+        }
+        
+        stage('Test ') {
+            when {
+                expression { !params.TESTS }
+            }
+            steps {
+                sh "mvn -B test"
+            }
+            post {
+                always {
+                    junit allowEmptyResults: true, testResults: '**/target/surefire-reports/**/TEST-*.xml'
+                    archiveArtifacts artifacts: '**/target/surefire-reports/**/TEST-*.xml', fingerprint: true
+                }
+            }
+        }
+
+        stage('Deploy SNAPSHOT to artifactory') {
+            when {
+                expression { return isMainBranch() }
+            }
+            steps {
+                sh "mvn deploy -s settings.xml -DskipTests"
+            }
+        }
+
+        stage('Deploy Release to artifactory') {
+            when {
+                expression { return isReleaseTag() }
+            }
+            steps {
+                sh "mvn deploy -s settings.xml -DskipTests"
+            }
+        }
+    }
+}
+
+
+def isReleaseTag() {
+    return (env.TAG_NAME =~ /^release-.*$/)
+}
+
+def isMainBranch() { //temp change to master later
+    return (env.BRANCH_NAME =~ /^ronanb\/*/) }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,6 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
     }
 
-
     tools {
         maven "maven"
     }
@@ -91,5 +90,6 @@ def isReleaseTag() {
     return (env.TAG_NAME =~ /^release-.*$/)
 }
 
-def isMainBranch() { //temp change to master later
-    return (env.BRANCH_NAME =~ /^ronanb\/*/) }
+def isMainBranch() {
+    return (env.BRANCH_NAME =~ /^master$/)
+}

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.cli</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH CLI</name>
   <description>The CRaSH command line interface module</description>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Connectors</name>
 

--- a/connectors/ssh/pom.xml
+++ b/connectors/ssh/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.connectors</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors.ssh</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Connectors - SSH</name>
   <description>The CRaSH SSH connector</description>

--- a/connectors/telnet/pom.xml
+++ b/connectors/telnet/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.connectors</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors.telnet</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Connectors - Telnet</name>
   <description>The CRaSH Telnet connector</description>

--- a/connectors/web/pom.xml
+++ b/connectors/web/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.connectors</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors.web</artifactId>
   <packaging>war</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Connectors - Web</name>
   <description>The CRaSH Web connector</description>

--- a/distrib/pom.xml
+++ b/distrib/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.distrib</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Distrib</name>
   <description>The CRaSH distribution</description>

--- a/doc/api/pom.xml
+++ b/doc/api/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>crash.doc</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc.api</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Doc API</name>
   <description>The CRaSH API documentation</description>

--- a/doc/cookbook/pom.xml
+++ b/doc/cookbook/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>crash.doc</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc.cookbook</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Doc Cookbook</name>
   <description>The CRaSH cookbook documentation</description>

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Doc</name>
 

--- a/doc/reference/pom.xml
+++ b/doc/reference/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>crash.doc</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc.reference</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Doc Reference</name>
   <description>The CRaSH reference documentation</description>

--- a/embed/pom.xml
+++ b/embed/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.embed</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Embed</name>
 

--- a/embed/spring/pom.xml
+++ b/embed/spring/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.embed</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.embed.spring</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Embed Spring</name>
   <description>The CRaSH Spring integration module</description>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.packaging</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Packaging</name>
   <description>The CRaSH packaging module</description>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.plugins</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Plugins</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.crashub</groupId>
   <artifactId>crash.parent</artifactId>
   <packaging>pom</packaging>
-    <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.4-SNAPSHOT</version>
   <!-- To update project version run the following:
     mvn versions:set -DnewVersion=<new version>
     mvn versions:commit # Necessary to remove the backup file pom.xml
@@ -106,12 +106,12 @@
   <dependencyManagement>
     <dependencies>
 
-      <!-- <dependency>
+      <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>3.0.1</version>
         <scope>provided</scope>
-      </dependency> -->
+      </dependency> 
       <!-- Module cli -->
       <dependency>
         <groupId>org.crashub</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.crashub</groupId>
   <artifactId>crash.parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
   <!-- To update project version run the following:
     mvn versions:set -DnewVersion=<new version>
     mvn versions:commit # Necessary to remove the backup file pom.xml
@@ -116,12 +116,12 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.cli</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.cli</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -129,25 +129,25 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <type>jar</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <type>test-jar</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <classifier>standalone</classifier>
       </dependency>
 
@@ -155,18 +155,18 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.telnet</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.telnet</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.telnet</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <classifier>standalone</classifier>
       </dependency>
 
@@ -174,18 +174,18 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.ssh</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.ssh</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.ssh</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <classifier>standalone</classifier>
       </dependency>
 
@@ -193,12 +193,12 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.web</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.web</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -206,12 +206,12 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.embed.spring</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.embed.spring</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -219,32 +219,32 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <type>war</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <type>war</type>
         <classifier>spring</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <type>zip</type>
         <classifier>mule-app</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <type>tar.gz</type>
       </dependency>
 
@@ -280,7 +280,7 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.api</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <classifier>javadoc</classifier>
       </dependency>
 
@@ -288,13 +288,13 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.reference</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <type>pdf</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.reference</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <classifier>html</classifier>
         <type>zip</type>
       </dependency>
@@ -303,13 +303,13 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.cookbook</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <type>pdf</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.cookbook</artifactId>
-        <version>1.7.4-SNAPSHOT</version>
+        <version>1.7.6-SNAPSHOT</version>
         <classifier>html</classifier>
         <type>zip</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.crashub</groupId>
   <artifactId>crash.parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>TEST-0.0.0-SNAPSHOT</version>
   <!-- To update project version run the following:
     mvn versions:set -DnewVersion=<new version>
     mvn versions:commit # Necessary to remove the backup file pom.xml
@@ -106,12 +106,12 @@
   <dependencyManagement>
     <dependencies>
 
-      <dependency>
+      <!-- <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>3.0.1</version>
         <scope>provided</scope>
-      </dependency>
+      </dependency> -->
       <!-- Module cli -->
       <dependency>
         <groupId>org.crashub</groupId>
@@ -708,6 +708,33 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>1.1</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.jfrog.buildinfo</groupId>
+          <artifactId>artifactory-maven-plugin</artifactId>
+          <version>2.2.1.</version>
+          <executions>
+            <execution>
+              <id>build-info</id>
+              <goals>
+                <goal>publish</goal>
+              </goals>
+              <configuration>
+                <!-- <deployProperties>
+                  <zip.deployed>true</zip.deployed>
+                  <zip.type>docs</zip.type>
+                </deployProperties> -->
+                <publisher>
+                  <contextUrl>https://software.r3.com/artifactory</contextUrl>
+                   <username>${env.CORDA_ARTIFACTORY_USERNAME}</username>
+                   <password>${env.CORDA_ARTIFACTORY_PASSWORD}</password>
+                  <repoKey>corda-dependencies</repoKey>
+                  <snapshotRepoKey>corda-dependencies-dev</snapshotRepoKey>
+                </publisher>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <artifactId>javax.servlet-api</artifactId>
         <version>3.0.1</version>
         <scope>provided</scope>
-      </dependency> 
+      </dependency>
       <!-- Module cli -->
       <dependency>
         <groupId>org.crashub</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -863,7 +863,7 @@
                 <execution>
                   <id>default-test</id>
                   <configuration>
-                    <skip>true</skip>
+                    <skip>false</skip>
                   </configuration>
                 </execution>
               </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.crashub</groupId>
   <artifactId>crash.parent</artifactId>
   <packaging>pom</packaging>
-  <version>TEST-0.0.0-SNAPSHOT</version>
+    <version>1.7.4-SNAPSHOT</version>
   <!-- To update project version run the following:
     mvn versions:set -DnewVersion=<new version>
     mvn versions:commit # Necessary to remove the backup file pom.xml
@@ -528,6 +528,19 @@
     <module>plugins</module>
     <module>distrib</module>
   </modules>
+
+<distributionManagement>
+    <repository>
+        <id>credentals</id>
+        <name>software.r3.com-releases</name>
+        <url>https://software.r3.com:443/artifactory/corda-dependencies</url>
+    </repository>
+    <snapshotRepository>
+        <id>credentals</id>
+        <name>software.r3.com-snapshots</name>
+        <url>https://software.r3.com:443/artifactory/corda-dependencies-dev</url>
+    </snapshotRepository>
+</distributionManagement>
   
   <build>
     <pluginManagement>
@@ -708,33 +721,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>1.1</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.jfrog.buildinfo</groupId>
-          <artifactId>artifactory-maven-plugin</artifactId>
-          <version>2.2.1.</version>
-          <executions>
-            <execution>
-              <id>build-info</id>
-              <goals>
-                <goal>publish</goal>
-              </goals>
-              <configuration>
-                <!-- <deployProperties>
-                  <zip.deployed>true</zip.deployed>
-                  <zip.type>docs</zip.type>
-                </deployProperties> -->
-                <publisher>
-                  <contextUrl>https://software.r3.com/artifactory</contextUrl>
-                   <username>${env.CORDA_ARTIFACTORY_USERNAME}</username>
-                   <password>${env.CORDA_ARTIFACTORY_PASSWORD}</password>
-                  <repoKey>corda-dependencies</repoKey>
-                  <snapshotRepoKey>corda-dependencies-dev</snapshotRepoKey>
-                </publisher>
-              </configuration>
-            </execution>
-          </executions>
         </plugin>
 
       </plugins>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,14 @@
+  <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <servers>
+        <server>
+            <id>credentals</id>
+            <username>${env.CORDA_ARTIFACTORY_USERNAME}</username>
+            <password>${env.CORDA_ARTIFACTORY_PASSWORD}</password>
+        </server>
+    </servers>
+
+</settings>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.4-SNAPSHOT</version>
+    <version>1.7.6-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.shell</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.4-SNAPSHOT</version>
+  <version>1.7.6-SNAPSHOT</version>
 
   <name>CRaSH Shell</name>
   <description>The Shell module</description>


### PR DESCRIPTION
1.7.5 has already been released

this commit adds logic necessary for further releases and increments version to 1.7.6-SNAPSHOT (Subsequent releases would be 1.7.6)

