### PR TITLE
ENT-11789: Updated dependent mina sshd and BC

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,8 +42,7 @@ pipeline {
 
         stage('Build ') {
             steps {
-                sh "mvn -B install -DskipTests"
-
+                sh "mvn -B install -DskipTests --settings ./settings.xml"
             }
         }
 

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -17,5 +17,4 @@
     <module>ssh</module>
     <module>web</module>
   </modules>
-
 </project>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -17,4 +17,5 @@
     <module>ssh</module>
     <module>web</module>
   </modules>
+
 </project>

--- a/connectors/ssh/pom.xml
+++ b/connectors/ssh/pom.xml
@@ -31,11 +31,11 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-lts8on</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-lts8on</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.mina</groupId>
@@ -127,5 +127,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -71,11 +71,11 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-lts8on</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-lts8on</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.mina</groupId>

--- a/packaging/src/main/assembly/mule-app.xml
+++ b/packaging/src/main/assembly/mule-app.xml
@@ -36,8 +36,8 @@
         <include>org.slf4j:slf4j-jdk14</include>
         <include>org.apache.sshd:sshd-core</include>
         <include>org.apache.sshd:sshd-pam</include>
-        <include>org.bouncycastle:bcprov-jdk15on</include>
-        <include>org.bouncycastle:bcpkix-jdk15on</include>
+        <include>org.bouncycastle:bcprov-lts8on</include>
+        <include>org.bouncycastle:bcpkix-lts8on</include>
         <include>org.apache.mina:mina-core</include>
         <include>net.wimpi:telnetd-x</include>
         <include>org.apache.ivy:ivy</include>

--- a/packaging/src/main/assembly/packaging.xml
+++ b/packaging/src/main/assembly/packaging.xml
@@ -43,8 +43,8 @@
         <include>org.apache.ivy:ivy</include>
         <include>org.crashub:crash.connectors.telnet:jar:standalone</include>
         <include>org.crashub:crash.connectors.ssh:jar:standalone</include>
-        <include>org.bouncycastle:bcprov-jdk15on</include>
-        <include>org.bouncycastle:bcpkix-jdk15on</include>
+        <include>org.bouncycastle:bcprov-lts8on</include>
+        <include>org.bouncycastle:bcpkix-lts8on</include>
       </includes>
     </dependencySet>
   </dependencySets>

--- a/packaging/src/main/assembly/spring.xml
+++ b/packaging/src/main/assembly/spring.xml
@@ -36,8 +36,8 @@
         <include>org.slf4j:slf4j-jdk14</include>
         <include>org.apache.sshd:sshd-core</include>
         <include>org.apache.sshd:sshd-pam</include>
-        <include>org.bouncycastle:bcprov-jdk15on</include>
-        <include>org.bouncycastle:bcpkix-jdk15on</include>
+        <include>org.bouncycastle:bcprov-lts8on</include>
+        <include>org.bouncycastle:bcpkix-lts8on</include>
         <include>org.apache.mina:mina-core</include>
         <include>net.wimpi:telnetd-x</include>
         <include>org.codehaus.groovy:groovy-all</include>

--- a/packaging/src/main/assembly/war.xml
+++ b/packaging/src/main/assembly/war.xml
@@ -36,8 +36,8 @@
         <include>org.slf4j:slf4j-jdk14</include>
         <include>org.apache.sshd:sshd-core</include>
         <include>org.apache.sshd:sshd-pam</include>
-        <include>org.bouncycastle:bcprov-jdk15on</include>
-        <include>org.bouncycastle:bcpkix-jdk15on</include>
+        <include>org.bouncycastle:bcprov-lts8on</include>
+        <include>org.bouncycastle:bcpkix-lts8on</include>
         <include>org.apache.mina:mina-core</include>
         <include>net.wimpi:telnetd-x</include>
         <include>org.codehaus.groovy:groovy-all</include>

--- a/packaging/src/main/spring/WEB-INF/jboss-deployment-structure.xml
+++ b/packaging/src/main/spring/WEB-INF/jboss-deployment-structure.xml
@@ -1,10 +1,10 @@
 <jboss-deployment-structure>
   <deployment>
     <resources>
-      <resource-root path="WEB-INF/lib/bcprov-jdk15on-1.49.jar" use-physical-code-source="true"/>
+      <resource-root path="WEB-INF/lib/bcprov-lts8on-2.73.6.jar" use-physical-code-source="true"/>
     </resources>
     <resources>
-      <resource-root path="WEB-INF/lib/bcpkix-jdk15on-1.49.jar" use-physical-code-source="true"/>
+      <resource-root path="WEB-INF/lib/bcpkix-lts15on-2.73.6.jar" use-physical-code-source="true"/>
     </resources>
   </deployment>
 </jboss-deployment-structure>

--- a/pom.xml
+++ b/pom.xml
@@ -102,10 +102,6 @@
       <url>https://jitpack.io</url>
     </repository>
     <repository>
-        <id>snapshot-repo</id>
-        <url>https://repository.apache.org/snapshots/</url>
-    </repository>
-    <repository>
       <id>credentals</id>
       <name>software.r3.com-releases</name>
       <url>https://software.r3.com:443/artifactory/corda-dependencies</url>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,15 @@
       <id>jitpack.io</id>
       <url>https://jitpack.io</url>
     </repository>
+    <repository>
+        <id>snapshot-repo</id>
+        <url>https://repository.apache.org/snapshots/</url>
+    </repository>
+    <repository>
+      <id>credentals</id>
+      <name>software.r3.com-releases</name>
+      <url>https://software.r3.com:443/artifactory/corda-dependencies</url>
+    </repository>
   </repositories>
 
   <dependencyManagement>
@@ -369,7 +378,7 @@
       <dependency>
         <groupId>org.apache.sshd</groupId>
         <artifactId>sshd-core</artifactId>
-        <version>2.9.2</version>
+        <version>2.13.0_r3</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -389,13 +398,13 @@
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
-        <version>1.51</version>
+        <artifactId>bcprov-lts8on</artifactId>
+        <version>2.73.6</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
-        <version>1.51</version>
+        <artifactId>bcpkix-lts8on</artifactId>
+        <version>2.73.6</version>
       </dependency>
       <dependency>
         <groupId>net.wimpi</groupId>


### PR DESCRIPTION
Upgrade BC to latest LTS release.
And now dependent on our own local fork of mina sshd, while we wait for apache mina team to do a new release. See https://github.com/apache/mina-sshd/issues/487.