### PR TITLE
ENT-11402: host binding for ssh shell

### DIFF
--- a/connectors/ssh/src/main/java/org/crsh/ssh/SSHPlugin.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/SSHPlugin.java
@@ -49,6 +49,9 @@ public class SSHPlugin extends CRaSHPlugin<SSHPlugin> {
   /** The SSH server authentication timeout value. */
   private static final int SSH_SERVER_AUTH_DEFAULT_TIMEOUT = 10 * 60 * 1000;
 
+  /** The SSH host. */
+  public static final PropertyDescriptor<String> SSH_HOST = PropertyDescriptor.create("ssh.host", (String)null, "The SSH host");
+
   /** The SSH port. */
   public static final PropertyDescriptor<Integer> SSH_PORT = PropertyDescriptor.create("ssh.port", 2000, "The SSH port");
 
@@ -82,12 +85,17 @@ public class SSHPlugin extends CRaSHPlugin<SSHPlugin> {
 
   @Override
   protected Iterable<PropertyDescriptor<?>> createConfigurationCapabilities() {
-    return Arrays.<PropertyDescriptor<?>>asList(SSH_PORT, SSH_SERVER_KEYPATH, SSH_SERVER_KEYGEN, SSH_SERVER_AUTH_TIMEOUT,
+    return Arrays.<PropertyDescriptor<?>>asList(SSH_HOST, SSH_PORT, SSH_SERVER_KEYPATH, SSH_SERVER_KEYGEN, SSH_SERVER_AUTH_TIMEOUT,
         SSH_SERVER_IDLE_TIMEOUT, SSH_ENCODING, AuthenticationPlugin.AUTH);
   }
 
   @Override
   public void init() {
+
+    String host = getContext().getProperty(SSH_HOST);
+    if (host == null) {
+      log.log(Level.INFO, "Missing host configuration, using default host");
+    }
 
     Integer port = getContext().getProperty(SSH_PORT);
     if (port == null) {
@@ -184,6 +192,7 @@ public class SSHPlugin extends CRaSHPlugin<SSHPlugin> {
     SSHLifeCycle lifeCycle = new SSHLifeCycle(
         getContext(),
         encoding,
+        host,
         port,
         idleTimeout,
         authTimeout,

--- a/connectors/ssh/src/main/java/org/crsh/ssh/SSHPlugin.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/SSHPlugin.java
@@ -99,7 +99,7 @@ public class SSHPlugin extends CRaSHPlugin<SSHPlugin> {
 
     Integer port = getContext().getProperty(SSH_PORT);
     if (port == null) {
-      log.log(Level.INFO, "Could not boot SSHD due to missing due to missing port configuration");
+      log.log(Level.INFO, "Could not boot SSHD due to missing port configuration");
       return;
     }
 

--- a/connectors/ssh/src/main/java/org/crsh/ssh/SSHPlugin.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/SSHPlugin.java
@@ -50,7 +50,7 @@ public class SSHPlugin extends CRaSHPlugin<SSHPlugin> {
   private static final int SSH_SERVER_AUTH_DEFAULT_TIMEOUT = 10 * 60 * 1000;
 
   /** The SSH host. */
-  public static final PropertyDescriptor<String> SSH_HOST = PropertyDescriptor.create("ssh.host", (String)null, "The SSH host");
+  public static final PropertyDescriptor<String> SSH_HOST = PropertyDescriptor.create("ssh.host", "0.0.0.0", "The SSH host");
 
   /** The SSH port. */
   public static final PropertyDescriptor<Integer> SSH_PORT = PropertyDescriptor.create("ssh.port", 2000, "The SSH port");
@@ -94,7 +94,7 @@ public class SSHPlugin extends CRaSHPlugin<SSHPlugin> {
 
     String host = getContext().getProperty(SSH_HOST);
     if (host == null) {
-      log.log(Level.INFO, "Missing host configuration, using default host");
+      log.log(Level.FINE, "No host configuration, using default host");
     }
 
     Integer port = getContext().getProperty(SSH_PORT);

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
@@ -62,6 +62,9 @@ public class SSHLifeCycle {
   private final PluginContext context;
 
   /** . */
+  private final String host;
+
+  /** . */
   private final int port;
 
   /** . */
@@ -88,6 +91,7 @@ public class SSHLifeCycle {
   public SSHLifeCycle(
       PluginContext context,
       Charset encoding,
+      String host,
       int port,
       int idleTimeout,
       int authTimeout,
@@ -96,6 +100,7 @@ public class SSHLifeCycle {
     this.authenticationPlugins = authenticationPlugins;
     this.context = context;
     this.encoding = encoding;
+    this.host = host;
     this.port = port;
     this.idleTimeout = idleTimeout;
     this.authTimeout = authTimeout;
@@ -105,6 +110,8 @@ public class SSHLifeCycle {
   public Charset getEncoding() {
     return encoding;
   }
+
+  public String getHost() { return host; }
 
   public int getPort() {
     return port;
@@ -140,6 +147,7 @@ public class SSHLifeCycle {
 
       //
       SshServer server = SshServer.setUpDefaultServer();
+      if (host != null) { server.setHost(host); }
       server.setPort(port);
 
       if (this.idleTimeout > 0) {

--- a/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
+++ b/connectors/ssh/src/main/java/org/crsh/ssh/term/SSHLifeCycle.java
@@ -147,7 +147,7 @@ public class SSHLifeCycle {
 
       //
       SshServer server = SshServer.setUpDefaultServer();
-      if (host != null) { server.setHost(host); }
+      server.setHost(host);
       server.setPort(port);
 
       if (this.idleTimeout > 0) {


### PR DESCRIPTION
Added an extra config option: `crash.ssh.host` 

This allows applications that use `corda/crash` to specify a crash config option to bind their ssh server to a specific IP