### PR TITLE
ENT-12921 - Updated mina-core version

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.cli</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH CLI</name>
   <description>The CRaSH command line interface module</description>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Connectors</name>
 

--- a/connectors/ssh/pom.xml
+++ b/connectors/ssh/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.connectors</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors.ssh</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Connectors - SSH</name>
   <description>The CRaSH SSH connector</description>

--- a/connectors/telnet/pom.xml
+++ b/connectors/telnet/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.connectors</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors.telnet</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Connectors - Telnet</name>
   <description>The CRaSH Telnet connector</description>

--- a/connectors/web/pom.xml
+++ b/connectors/web/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.connectors</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.connectors.web</artifactId>
   <packaging>war</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Connectors - Web</name>
   <description>The CRaSH Web connector</description>

--- a/distrib/pom.xml
+++ b/distrib/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.distrib</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Distrib</name>
   <description>The CRaSH distribution</description>

--- a/doc/api/pom.xml
+++ b/doc/api/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>crash.doc</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc.api</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Doc API</name>
   <description>The CRaSH API documentation</description>

--- a/doc/cookbook/pom.xml
+++ b/doc/cookbook/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>crash.doc</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc.cookbook</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Doc Cookbook</name>
   <description>The CRaSH cookbook documentation</description>

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Doc</name>
 

--- a/doc/reference/pom.xml
+++ b/doc/reference/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <artifactId>crash.doc</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.doc.reference</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Doc Reference</name>
   <description>The CRaSH reference documentation</description>

--- a/embed/pom.xml
+++ b/embed/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.embed</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Embed</name>
 

--- a/embed/spring/pom.xml
+++ b/embed/spring/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.embed</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.embed.spring</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Embed Spring</name>
   <description>The CRaSH Spring integration module</description>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.packaging</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Packaging</name>
   <description>The CRaSH packaging module</description>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.plugins</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Plugins</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.crashub</groupId>
   <artifactId>crash.parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
   <!-- To update project version run the following:
     mvn versions:set -DnewVersion=<new version>
     mvn versions:commit # Necessary to remove the backup file pom.xml
@@ -121,12 +121,12 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.cli</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.cli</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -134,25 +134,25 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <type>jar</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <type>test-jar</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.shell</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <classifier>standalone</classifier>
       </dependency>
 
@@ -160,18 +160,18 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.telnet</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.telnet</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.telnet</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <classifier>standalone</classifier>
       </dependency>
 
@@ -179,18 +179,18 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.ssh</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.ssh</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.ssh</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <classifier>standalone</classifier>
       </dependency>
 
@@ -198,12 +198,12 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.web</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.connectors.web</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -211,12 +211,12 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.embed.spring</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.embed.spring</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -224,32 +224,32 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <type>war</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <type>war</type>
         <classifier>spring</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <type>zip</type>
         <classifier>mule-app</classifier>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.packaging</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <type>tar.gz</type>
       </dependency>
 
@@ -285,7 +285,7 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.api</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <classifier>javadoc</classifier>
       </dependency>
 
@@ -293,13 +293,13 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.reference</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <type>pdf</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.reference</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <classifier>html</classifier>
         <type>zip</type>
       </dependency>
@@ -308,13 +308,13 @@
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.cookbook</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <type>pdf</type>
       </dependency>
       <dependency>
         <groupId>org.crashub</groupId>
         <artifactId>crash.doc.cookbook</artifactId>
-        <version>1.7.6-SNAPSHOT</version>
+        <version>1.7.7-SNAPSHOT</version>
         <classifier>html</classifier>
         <type>zip</type>
       </dependency>
@@ -390,7 +390,7 @@
       <dependency>
         <groupId>org.apache.mina</groupId>
         <artifactId>mina-core</artifactId>
-        <version>2.0.22</version>
+        <version>2.0.27</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -2,12 +2,12 @@
   <parent>
     <artifactId>crash.parent</artifactId>
     <groupId>org.crashub</groupId>
-    <version>1.7.6-SNAPSHOT</version>
+    <version>1.7.7-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>crash.shell</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.6-SNAPSHOT</version>
+  <version>1.7.7-SNAPSHOT</version>
 
   <name>CRaSH Shell</name>
   <description>The Shell module</description>


### PR DESCRIPTION
Updated mina-core to get past security vulnerability - see the mina-core entry in the top-level pom.xml.
Also moved the overall version along to 1.7.7-SNAPSHOT, seeing as the latest tag is currently 1.7.7-RC02, this project should be on version 1.7.7.
